### PR TITLE
Fixed odd child nodes being accessible through node property

### DIFF
--- a/addons/godot_xml/xml_node.gd
+++ b/addons/godot_xml/xml_node.gd
@@ -137,11 +137,19 @@ func _get_property_list() -> Array[Dictionary]:
 func _initialize_node_properties() -> void:
     var names_to_nodes := {}
 
+    # Adds children with same name in same Array
     for child: XMLNode in self.children:
-        if not child.name in names_to_nodes.keys():
-            names_to_nodes[child.name] = child
-        else:
-            names_to_nodes.erase(child.name)
+        var name: String = child.name
+
+        if not name in names_to_nodes.keys():
+            names_to_nodes[name] = []
+        
+        names_to_nodes[name].append(child)
+    
+    # Removes Arrays with more than one child
+    for name: String in names_to_nodes.keys():
+        if names_to_nodes[name].size() > 1:
+            names_to_nodes.erase(name)
 
     self._node_props = names_to_nodes.keys()
     self._node_props_initialized = true


### PR DESCRIPTION
## Overview
In this Pull Request, small modifications to the `XMLNode` class were introduced. These changes are, more precisely, in the `_initialize_node_properties` method. Their purpose is to fix the behavior described on the issue #37, which made it so nodes with an odd number of children with the same name could access them as if they had only one.

This bug was happening because the old implementation used one `for` loop to iterate over the children, adding them to a `Dictionary` if they weren't already present, and removing them if they were. This essentially created an alternate cycle of addition/ removal from the `Dictionary`, which, in the case of odd children, would end up letting the last child left in the `Dictionary`.

This was fixed by, instead of storing those children directly in a `Dictionary`, storing them in `Arrays` inside that `Dictionary`.
That way the `Dictionary` can still provide unique access to the children names, but these names can lead to more than one child.
After the loop responsible for storing these children, another loop iterates over the `Dictionary` entries in order to remove the ones that store more than one child.

## Related Issues
fixes #37 

## Checklist
- [X] I have tested my changes in Godot 4.2.2.
